### PR TITLE
Modified S50date to explicitly specify the date file path

### DIFF
--- a/board/common/overlay/etc/init.d/S50date
+++ b/board/common/overlay/etc/init.d/S50date
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Date executable points to /bin/busybox\ date explicitly in the cases that date binary gets overwritten
+date_exec=/bin/busybox\ date
+
 sys_conf="/etc/date.conf"
 boot_conf="/boot/date.conf"
 conf="/data/etc/date.conf"
@@ -41,7 +44,7 @@ source $conf
 set_current_date_http() {
     date_str=$(curl -v -s -m $date_timeout -X GET http://$date_host 2>&1 | grep Date | sed -e 's/< Date: //')
     test -z "$date_str" && return 1
-    date -u -D "%a, %d %b %Y %H:%M:%S" -s "$date_str" > /dev/null
+    $date_exec -u -D "%a, %d %b %Y %H:%M:%S" -s "$date_str" > /dev/null
     return $?
 }
 
@@ -52,7 +55,7 @@ set_current_date_ntp() {
 start_http() {
     msg_begin "Setting current date using http"
     set_current_date_http || set_current_date_http
-    test $? == 0 && msg_done "$(date)" || msg_fail
+    test $? == 0 && msg_done "$($date_exec)" || msg_fail
     
     msg_begin "Starting http date updater"
     while true; do
@@ -78,7 +81,7 @@ start_ntp() {
 
     msg_begin "Setting current date using ntp"
     set_current_date_ntp || set_current_date_ntp
-    test $? == 0 && msg_done "$(date)" || msg_fail
+    test $? == 0 && msg_done "$($date_exec)" || msg_fail
 
     msg_begin "Starting ntpd"
     ntpd -g -c $ntp_conf
@@ -104,7 +107,7 @@ start() {
         start_ntp
     fi
 
-    echo "system date is $(date '+%Y-%m-%d %H:%M:%S')" > /dev/kmsg
+    echo "system date is $($date_exec '+%Y-%m-%d %H:%M:%S')" > /dev/kmsg
 }
 
 stop() {


### PR DESCRIPTION
Explicitly specified the file path of the date binary to point to /bin/busybox\ date to account for the case the symlink has been overwritten by another package such as coreutils.